### PR TITLE
Fix top-level code sample with initial_node_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ end
 
 gcontainer_cluster 'test-cluster' do
   action :create
+  initial_node_count 4
   zone 'us-central1-a'
   project 'google.com:graphite-playground'
   credential 'mycred'
@@ -39,7 +40,6 @@ end
 
 gcontainer_node_pool 'web-servers' do
   action :create
-  initial_node_count 4
   cluster 'test-cluster'
   zone 'us-central1-a'
   project 'google.com:graphite-playground'


### PR DESCRIPTION
Running the top-level code sample results in an error:
```
[2018-03-30T23:36:55+00:00] ERROR: gcontainer_cluster[test-cluster] (google-cloud::gcontainer line 9) had an error: RuntimeError: Bad response: {
  "error": {
    "code": 400,
    "message": "cluster.initial_node_count must be greater than zero.",
    "status": "INVALID_ARGUMENT"
  }
}
```

Swapping the `initial_node_count` attribute from the node pool to the cluster resource fixes it.